### PR TITLE
Feature/routing setup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "labs-fe",
       "version": "0.1.0",
       "dependencies": {
         "@testing-library/jest-dom": "^5.11.4",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,38 @@
 import React from "react";
 import "./App.css";
+import {
+  Route, Switch,
+} from "react-router-dom";
+
+//* * Component Imports **/
 import NavigationHeader from "./components/Navigation/Navigation";
+import Attendance from "./components/Attendance/Attendance";
+import TeamBuilder from "./components/TeamBuilder/TeamBuilder";
+import LearnerSuccess from "./components/LearnerSuccess/LearnerSuccess";
+import FourthComponent from "./components/FourthComponent/FourthComponent";
+import Home from "./components/Home/Home";
 
 const App = (): any => (
-  <NavigationHeader />
-
+  <>
+    <NavigationHeader />
+    <Switch>
+      <Route exact path="/">
+        <Home />
+      </Route>
+      <Route path="/attendance">
+        <Attendance />
+      </Route>
+      <Route path="/teambuilder">
+        <TeamBuilder />
+      </Route>
+      <Route path="/learnersuccess">
+        <LearnerSuccess />
+      </Route>
+      <Route path="/fourth">
+        <FourthComponent />
+      </Route>
+    </Switch>
+  </>
 );
 
 export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import NavigationHeader from "./components/Navigation/Navigation";
 
 const App = (): any => (
   <NavigationHeader />
+
 );
 
 export default App;

--- a/src/components/Attendance/Attendance.tsx
+++ b/src/components/Attendance/Attendance.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+const Attendance = (): any => (
+
+  <h1>Attendance Component</h1>
+
+);
+
+export default Attendance;

--- a/src/components/Attendance/Attendance.tsx
+++ b/src/components/Attendance/Attendance.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 
-const Attendance = (): any => (
-
-  <h1>Attendance Component</h1>
-
-);
+function Attendance(): any {
+  return (
+    <h1>Attendance Component</h1>
+  );
+}
 
 export default Attendance;

--- a/src/components/FourthComponent/FourthComponent.tsx
+++ b/src/components/FourthComponent/FourthComponent.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+function FourthComponent(): any {
+  return (
+    <h1>
+      This is a stub for a 4th expected functionality for Labby2.0
+      - implementing for route configuration
+    </h1>
+  );
+}
+
+export default FourthComponent;

--- a/src/components/Home/Home.tsx
+++ b/src/components/Home/Home.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+function Home(): any {
+  return (
+    <h1>Home Component</h1>
+  );
+}
+
+export default Home;

--- a/src/components/LearnerSuccess/LearnerSuccess.tsx
+++ b/src/components/LearnerSuccess/LearnerSuccess.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-function LearnerSuccess() {
+function LearnerSuccess(): any {
   return (
     <h1>Learner Success Auditing Component</h1>
   );

--- a/src/components/LearnerSuccess/LearnerSuccess.tsx
+++ b/src/components/LearnerSuccess/LearnerSuccess.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+function LearnerSuccess() {
+  return (
+    <h1>Learner Success Auditing Component</h1>
+  );
+}
+
+export default LearnerSuccess;

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Layout, Menu } from "antd";
+import { Link } from "react-router-dom";
 
 const { Header } = Layout;
 
@@ -9,7 +10,7 @@ function NavigationHeader(): any {
       <Header>
         <div className="logo" />
         <Menu mode="horizontal">
-          <Menu.Item>Link 1</Menu.Item>
+          <Menu.Item><Link to="/attendance">Attendance Tracker</Link></Menu.Item>
           <Menu.Item>Link 1</Menu.Item>
           <Menu.Item>Link 1</Menu.Item>
           <Menu.Item>Link 1</Menu.Item>

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -10,10 +10,31 @@ function NavigationHeader(): any {
       <Header>
         <div className="logo" />
         <Menu mode="horizontal">
-          <Menu.Item><Link to="/attendance">Attendance Tracker</Link></Menu.Item>
-          <Menu.Item>Link 1</Menu.Item>
-          <Menu.Item>Link 1</Menu.Item>
-          <Menu.Item>Link 1</Menu.Item>
+          <Menu.Item>
+            <Link to="/">
+              Home
+            </Link>
+          </Menu.Item>
+          <Menu.Item>
+            <Link to="/attendance">
+              Attendance Tracker
+            </Link>
+          </Menu.Item>
+          <Menu.Item>
+            <Link to="/teambuilder">
+              Team Builder
+            </Link>
+          </Menu.Item>
+          <Menu.Item>
+            <Link to="/learnersuccess">
+              Learner Success Auditing
+            </Link>
+          </Menu.Item>
+          <Menu.Item>
+            <Link to="/fourth">
+              Fourth Component
+            </Link>
+          </Menu.Item>
         </Menu>
       </Header>
     </Layout>

--- a/src/components/TeamBuilder/TeamBuilder.tsx
+++ b/src/components/TeamBuilder/TeamBuilder.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+function TeamBuilder() {
+  return (
+    <h1>Team Builder Component</h1>
+  );
+}
+
+export default TeamBuilder;

--- a/src/components/TeamBuilder/TeamBuilder.tsx
+++ b/src/components/TeamBuilder/TeamBuilder.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-function TeamBuilder() {
+function TeamBuilder(): any {
   return (
     <h1>Team Builder Component</h1>
   );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,12 +5,14 @@ import {
   BrowserRouter as Router, Route, Link, Switch,
 } from "react-router-dom";
 import App from "./App";
+import Attendance from "./components/Attendance/Attendance";
 
 ReactDOM.render(
   <Router>
+    <App />
     <Switch>
-      <Route exact path="/">
-        <App />
+      <Route path="/attendance">
+        <Attendance />
       </Route>
     </Switch>
   </Router>,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,28 +5,10 @@ import {
   BrowserRouter as Router, Route, Link, Switch,
 } from "react-router-dom";
 import App from "./App";
-import Attendance from "./components/Attendance/Attendance";
-import TeamBuilder from "./components/TeamBuilder/TeamBuilder";
-import LearnerSuccess from "./components/LearnerSuccess/LearnerSuccess";
-import FourthComponent from "./components/FourthComponent/FourthComponent";
 
 ReactDOM.render(
   <Router>
     <App />
-    <Switch>
-      <Route path="/attendance">
-        <Attendance />
-      </Route>
-      <Route path="/teambuilder">
-        <TeamBuilder />
-      </Route>
-      <Route path="/learnersuccess">
-        <LearnerSuccess />
-      </Route>
-      <Route path="/fourth">
-        <FourthComponent />
-      </Route>
-    </Switch>
   </Router>,
   document.getElementById("root"),
 );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,14 +1,18 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import "./index.css";
-import { BrowserRouter as Router, Route, Link } from "react-router-dom";
+import {
+  BrowserRouter as Router, Route, Link, Switch,
+} from "react-router-dom";
 import App from "./App";
 
 ReactDOM.render(
   <Router>
-    <Route>
-      <App />
-    </Route>
+    <Switch>
+      <Route exact path="/">
+        <App />
+      </Route>
+    </Switch>
   </Router>,
   document.getElementById("root"),
 );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,9 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import "./index.css";
-import {
-  BrowserRouter as Router, Route, Link, Switch,
-} from "react-router-dom";
+import { BrowserRouter as Router } from "react-router-dom";
 import App from "./App";
 
 ReactDOM.render(

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,6 +6,9 @@ import {
 } from "react-router-dom";
 import App from "./App";
 import Attendance from "./components/Attendance/Attendance";
+import TeamBuilder from "./components/TeamBuilder/TeamBuilder";
+import LearnerSuccess from "./components/LearnerSuccess/LearnerSuccess";
+import FourthComponent from "./components/FourthComponent/FourthComponent";
 
 ReactDOM.render(
   <Router>
@@ -13,6 +16,15 @@ ReactDOM.render(
     <Switch>
       <Route path="/attendance">
         <Attendance />
+      </Route>
+      <Route path="/teambuilder">
+        <TeamBuilder />
+      </Route>
+      <Route path="/learnersuccess">
+        <LearnerSuccess />
+      </Route>
+      <Route path="/fourth">
+        <FourthComponent />
       </Route>
     </Switch>
   </Router>,


### PR DESCRIPTION
This pull request adds basic routing configuration, as well as adds some stub components onto which we can build the front-end portion of the expected Labby 2.0 features by using `react-router-dom`. Accompanying this routing setup, I've included the appropriate links to each stub component for which a route was built by adding `react-router-dom`'s `Link`s to the ANT Design NavBar Ryan implemented earlier in the day.

This keeps with the standards set so far by Ryan and myself and leaves us off at a good place from which to build out these features and stub out the API connections to the `labs-be`.